### PR TITLE
feat: add basic service structure

### DIFF
--- a/authorization-service/.gitignore
+++ b/authorization-service/.gitignore
@@ -1,0 +1,13 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# Webpack directories
+.webpack
+
+package-lock.json
+.vscode
+.env

--- a/authorization-service/functions/basicAuthorizer.ts
+++ b/authorization-service/functions/basicAuthorizer.ts
@@ -20,6 +20,6 @@ export const basicAuthorizer: APIGatewayTokenAuthorizerHandler = async (event, _
         const policy = generatePolicy(encodedCredentials, event.methodArn, effect);
         return policy;
     } catch(err) {
-        callback(`Unauthorized: ${err.message}`);
+        callback('Unauthorized');
     }
   }

--- a/authorization-service/functions/basicAuthorizer.ts
+++ b/authorization-service/functions/basicAuthorizer.ts
@@ -2,7 +2,6 @@ import { APIGatewayTokenAuthorizerHandler } from "aws-lambda";
 import { generatePolicy } from "../utils";
 
 export const basicAuthorizer: APIGatewayTokenAuthorizerHandler = async (event, _context, callback) => {
-    console.log('Hello');
     console.log('Event: ', JSON.stringify(event));
 
     if (event['type'] != 'TOKEN') callback('Unauthorized');

--- a/authorization-service/functions/basicAuthorizer.ts
+++ b/authorization-service/functions/basicAuthorizer.ts
@@ -1,0 +1,26 @@
+import { APIGatewayTokenAuthorizerHandler } from "aws-lambda";
+import { generatePolicy } from "../utils";
+
+export const basicAuthorizer: APIGatewayTokenAuthorizerHandler = async (event, _context, callback) => {
+    console.log('Hello');
+    console.log('Event: ', JSON.stringify(event));
+
+    if (event['type'] != 'TOKEN') callback('Unauthorized');
+
+    try {
+        const authorizationToken = event.authorizationToken;
+
+        const encodedCredentials = authorizationToken.split(' ')[1];
+        const plainCredentials = Buffer.from(encodedCredentials, 'base64').toString('utf-8').split(':');
+        const [username, password] = plainCredentials;
+
+        console.log(`username ${username} and password ${password}`);
+
+        const storedPassword = process.env[username];
+        const effect = !storedPassword || storedPassword !== password ? 'Deny' : 'Allow';
+        const policy = generatePolicy(encodedCredentials, event.methodArn, effect);
+        return policy;
+    } catch(err) {
+        callback(`Unauthorized: ${err.message}`);
+    }
+  }

--- a/authorization-service/handler.ts
+++ b/authorization-service/handler.ts
@@ -1,0 +1,3 @@
+import 'source-map-support/register';
+export * from './functions/basicAuthorizer';
+

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "authorization-service",
+  "version": "1.0.0",
+  "description": "Serverless webpack example using Typescript",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "source-map-support": "^0.5.10"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.17",
+    "@types/node": "^10.12.18",
+    "@types/serverless": "^1.72.5",
+    "fork-ts-checker-webpack-plugin": "^3.0.1",
+    "serverless-dotenv-plugin": "^3.1.0",
+    "serverless-webpack": "^5.2.0",
+    "ts-loader": "^5.3.3",
+    "ts-node": "^8.10.2",
+    "typescript": "^3.2.4",
+    "webpack": "^4.29.0",
+    "webpack-node-externals": "^1.7.2"
+  },
+  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/authorization-service/serverless.ts
+++ b/authorization-service/serverless.ts
@@ -1,0 +1,37 @@
+import type { Serverless } from 'serverless/aws';
+
+const serverlessConfiguration: Serverless = {
+  service: {
+    name: 'authorization-service',
+    // app and org for use with dashboard.serverless.com
+    // app: your-app-name,
+    // org: your-org-name,
+  },
+  frameworkVersion: '2',
+  custom: {
+    webpack: {
+      webpackConfig: './webpack.config.js',
+      includeModules: true
+    }
+  },
+  // Add the serverless-webpack plugin
+  plugins: ['serverless-webpack', 'serverless-dotenv-plugin'],
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs12.x',
+    apiGateway: {
+      minimumCompressionSize: 1024,
+    },
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+    },
+    region: 'eu-west-1',
+  },
+  functions: {
+    basicAuthorizer: {
+      handler: 'handler.basicAuthorizer'
+    }
+  }
+}
+
+module.exports = serverlessConfiguration;

--- a/authorization-service/tsconfig.json
+++ b/authorization-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "removeComments": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2017",
+    "outDir": "lib"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ]
+}

--- a/authorization-service/utils/index.ts
+++ b/authorization-service/utils/index.ts
@@ -1,0 +1,14 @@
+export const generatePolicy = (principalId, resource, effect = 'Allow') => {
+    return {
+        principalId,
+        policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                  Action: 'execute-api:Invoke',
+                  Effect: effect,
+                  Resource: resource  
+                }]
+        }
+    }
+}

--- a/authorization-service/webpack.config.js
+++ b/authorization-service/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'cheap-module-eval-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [
+    // new ForkTsCheckerWebpackPlugin({
+    //   eslint: true,
+    //   eslintOptions: {
+    //     cache: true
+    //   }
+    // })
+  ],
+};

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -29,6 +29,19 @@ const serverlessConfiguration: Serverless = {
         Properties: {
           QueueName: 'catalogItemsQueue'
         }
+      },
+      GatewayResponseDefault400: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+            'gatewayresponse.header.Access-Control-Allow-Headers': "'*'",
+          },
+          ResponseType: 'DEFAULT_4XX',
+          RestApiId: {
+            Ref: 'ApiGatewayRestApi',
+          },
+        },
       }
     }
   },
@@ -75,6 +88,7 @@ const serverlessConfiguration: Serverless = {
           http: {
             method: 'get',
             path: 'import',
+            cors: true,
             request: {
               parameters: {
                 querystrings: {

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -81,6 +81,13 @@ const serverlessConfiguration: Serverless = {
                   name: true
                 }
               }
+            },
+            authorizer: {
+              name: 'basicAuthorizer',
+              arn: 'arn:aws:lambda:eu-west-1:071136134726:function:authorization-service-dev-basicAuthorizer',
+              resultTtlInSeconds: 0,
+              identitySource: 'method.request.header.Authorization',
+              type: 'token'
             }
           }
         }


### PR DESCRIPTION
* **1** - **authorization-service** is added to the repo, has correct **basicAuthorizer** lambda and correct **serverless.yaml** file
* **3** - **import-service** serverless.yaml file has authorizer configuration for the **importProductsFile** lambda. Request to the **importProductsFile** lambda should work only with correct **authorization_token** being decoded and checked by **basicAuthorizer** lambda. Response should be in 403 HTTP status if access is denied for this user (invalid **authorization_token**) and in 401 HTTP status if Authorization header is not provided.
* **5** - update client application to send Authorization: Basic **authorization_token** header on import. Client should get **authorization_token** value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage
**authorization_token** = localStorage.getItem('**authorization_token**')
 
## Additional (optional) tasks
---
* **+1** - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the **nodejs-aws-fe-main/src/index.tsx** file

Link to frontend integration: https://d3fkc8nqapw81s.cloudfront.net
Link to frontend pull request: https://github.com/DevandScorp/aws-shop-frontend/pull/4